### PR TITLE
Make sure that 'leftHandler' en 'rightHandler' are not put as props on the DIV element in render

### DIFF
--- a/src/ReactScrollWheelHandler.js
+++ b/src/ReactScrollWheelHandler.js
@@ -252,6 +252,8 @@ class ReactScrollWheelHandler extends Component {
             customStyle,
             upHandler,
             downHandler,
+            leftHandler,
+            rightHandler,
             pauseListeners,
             disableKeyboard,
             preventScroll,


### PR DESCRIPTION
To prevent console warnings:

```
backend.js:6 Warning: React does not recognize the `leftHandler` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `lefthandler` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in div (created by t)
    in t (created by Context.Consumer)
    ...
```

and

```
backend.js:6 Warning: React does not recognize the `rightHandler` prop on a DOM element. If you intentionally want it to appear in the DOM as a custom attribute, spell it as lowercase `righthandler` instead. If you accidentally passed it from a parent component, remove it from the DOM element.
    in div (created by t)
    in t (created by Context.Consumer)
    ...
```