### PR TITLE
feat: add disableSwipeWithMouse prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,6 +68,7 @@ import ReactScrollWheelHandler from "react-scroll-wheel-handler";
 - **timeout**: Integer. isRequired. Default: 600. Timeout between scroll.
 - **disableKeyboard**: Boolean. Default: false.
 - **disableSwipe**: Boolean. Default: false.
+- **disableSwipeWithMouse**: Boolean. Default: false.
 - **preventScroll**: Boolean. isRequired. Prevent scroll, if you want to implement your own scrolling. Default: false.
 - **wheelConfig**: Array. Default: []. Set config for Lethargy lib. Example: [7, 100, 0.05]. stability, sensitivity, tolerance.
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,6 +5,7 @@
   "requires": true,
   "packages": {
     "": {
+      "name": "react-scroll-wheel-handler",
       "version": "2.1.0",
       "license": "ISC",
       "devDependencies": {
@@ -17701,6 +17702,7 @@
       "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-1.2.13.tgz",
       "integrity": "sha512-oWb1Z6mkHIskLzEJ/XWX0srkpkTQ7vaopMQkyaEIoq0fmtFVxOthb8cCxeT+p3ynTdkk/RZwbgG4brR5BeWECw==",
       "dev": true,
+      "hasInstallScript": true,
       "optional": true,
       "os": [
         "darwin"

--- a/src/ReactScrollWheelHandler.js
+++ b/src/ReactScrollWheelHandler.js
@@ -241,6 +241,7 @@ class ReactScrollWheelHandler extends Component {
       preventScroll,
       wheelConfig,
       disableSwipe,
+      disableSwipeWithMouse,
       ...otherProps
     } = this.props;
 
@@ -251,8 +252,8 @@ class ReactScrollWheelHandler extends Component {
       onKeyPress: this.handleKeyPress,
       tabIndex: "0",
       onTouchStart: touchStart,
-      onMouseDown: touchStart,
-      onMouseUp: touchEnd,
+      onMouseDown: !disableSwipeWithMouse ? touchStart : null,
+      onMouseUp: !disableSwipeWithMouse ? touchEnd : null,
       onTouchEnd: touchEnd,
       ref: this.containerRef,
     };
@@ -282,6 +283,7 @@ ReactScrollWheelHandler.propTypes = {
   timeout: PropTypes.number,
   disableKeyboard: PropTypes.bool.isRequired,
   disableSwipe: PropTypes.bool.isRequired,
+  disableSwipeWithMouse: PropTypes.bool.isRequired,
   preventScroll: PropTypes.bool.isRequired,
   wheelConfig: PropTypes.array,
 };
@@ -291,6 +293,7 @@ ReactScrollWheelHandler.defaultProps = {
   timeout: 700,
   disableKeyboard: false,
   disableSwipe: false,
+  disableSwipeWithMouse: false,
   preventScroll: false,
   wheelConfig: [],
 };

--- a/src/index.d.ts
+++ b/src/index.d.ts
@@ -1,20 +1,27 @@
-declare module 'react-scroll-wheel-handler' {
-  import { Component, DetailedHTMLProps, HTMLAttributes } from 'react';
+declare module "react-scroll-wheel-handler" {
+  import { Component, DetailedHTMLProps, HTMLAttributes } from "react";
 
-  export type ReactScrollWheelHandlerWheelConfig = [stability: number, sensitivity: number, tolerance: number, delay: number];
+  export type ReactScrollWheelHandlerWheelConfig = [
+    stability: number,
+    sensitivity: number,
+    tolerance: number,
+    delay: number
+  ];
 
-  export interface ReactScrollWheelHandlerProps extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
-    upHandler?: (event: WheelEvent) => void,
-    downHandler?: (event: WheelEvent) => void,
-    leftHandler?: (event: WheelEvent) => void,
-    rightHandler?: (event: WheelEvent) => void,
-    CustomComponent?: JSX.Element,
-    timeout?: number,
-    wheelConfig?: ReactScrollWheelHandlerWheelConfig,
-    pauseListeners?: boolean,
-    disableKeyboard?: boolean,
-    disableSwipe?: boolean,
-    preventScroll?: boolean,
+  export interface ReactScrollWheelHandlerProps
+    extends DetailedHTMLProps<HTMLAttributes<HTMLDivElement>, HTMLDivElement> {
+    upHandler?: (event: WheelEvent) => void;
+    downHandler?: (event: WheelEvent) => void;
+    leftHandler?: (event: WheelEvent) => void;
+    rightHandler?: (event: WheelEvent) => void;
+    CustomComponent?: JSX.Element;
+    timeout?: number;
+    wheelConfig?: ReactScrollWheelHandlerWheelConfig;
+    pauseListeners?: boolean;
+    disableKeyboard?: boolean;
+    disableSwipe?: boolean;
+    disableSwipeWithMouse?: boolean;
+    preventScroll?: boolean;
   }
 
   // eslint-disable-next-line react/prefer-stateless-function

--- a/tests/ReactScrollWheelHandler.test.js
+++ b/tests/ReactScrollWheelHandler.test.js
@@ -549,4 +549,18 @@ describe("ReactScrollWheelHandler", () => {
     expect(upHandler).toHaveBeenCalled();
     expect(component.instance().startTimeout).toHaveBeenCalled();
   });
+  it("should not run handler onMouseUp or down if disableSwipeWithMouse is disabled", () => {
+    const leftHandler = jest.fn();
+    const component = mount(
+      <ReactScrollWheelHandler
+        leftHandler={leftHandler}
+        disableSwipeWithMouse
+      />
+    );
+
+    const { onMouseDown, onMouseUp } = component.find("div").props();
+
+    expect(onMouseDown).toBe(null);
+    expect(onMouseUp).toBe(null);
+  });
 });


### PR DESCRIPTION
on default, this library handles mouse events and touch events for swipe. This prop might be useful for some use cases where you only want to trigger upHandler/downHandler using touchscreen swipe.